### PR TITLE
Add SQL dumps and PHP database wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,24 @@ npm run dev
 Notas:
 - Variables `NEXTAUTH_*` no son usadas por este proyecto (autenticación JWT propia).
 - Revisa `.env.example` para un ejemplo completo.
+
+## Migración a MySQL/MariaDB o PostgreSQL
+
+En el directorio `prisma/` se incluyen archivos SQL que replican el esquema definido en `schema.prisma`:
+
+- `schema.mysql.sql` para bases de datos MySQL o MariaDB.
+- `schema.postgres.sql` para bases de datos PostgreSQL.
+
+Estos archivos pueden importarse directamente desde cPanel u otro panel de control para preparar la base de datos sin necesidad de Prisma.
+
+### Uso desde PHP
+
+Si el proyecto se despliega en un entorno PHP, el directorio `php/` contiene un pequeño envoltorio basado en PDO que expone una conexión similar a `src/lib/prisma.ts`:
+
+```php
+require __DIR__ . '/php/Database.php';
+$db = Database::getInstance()->getConnection();
+$usuarios = $db->query('SELECT * FROM usuarios')->fetchAll();
+```
+
+Ajusta las variables de entorno `DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASS` o `DATABASE_URL` según tus credenciales.

--- a/php/Database.php
+++ b/php/Database.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Simple PDO wrapper that mirrors the Prisma client export used in
+ * src/lib/prisma.ts.  It exposes a singleton connection that can be
+ * retrieved anywhere in the application.
+ */
+class Database
+{
+    private static ?Database $instance = null;
+    private \PDO $pdo;
+
+    private function __construct()
+    {
+        $dsn = getenv('DATABASE_URL');
+        $username = getenv('DB_USER') ?: '';
+        $password = getenv('DB_PASS') ?: '';
+
+        if (!$dsn) {
+            // Fallback to a typical MySQL connection string
+            $host = getenv('DB_HOST') ?: 'localhost';
+            $db   = getenv('DB_NAME') ?: 'rifas';
+            $charset = 'utf8mb4';
+            $dsn = "mysql:host={$host};dbname={$db};charset={$charset}";
+        }
+
+        $options = [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ];
+
+        $this->pdo = new \PDO($dsn, $username, $password, $options);
+    }
+
+    /**
+     * Returns the singleton instance of the Database wrapper
+     */
+    public static function getInstance(): Database
+    {
+        if (self::$instance === null) {
+            self::$instance = new Database();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Provides access to the underlying PDO connection
+     */
+    public function getConnection(): \PDO
+    {
+        return $this->pdo;
+    }
+
+    /**
+     * Executes a prepared statement with optional parameters and returns
+     * the resulting PDOStatement.
+     */
+    public function query(string $sql, array $params = []): \PDOStatement
+    {
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+        return $stmt;
+    }
+}
+?>

--- a/prisma/schema.mysql.sql
+++ b/prisma/schema.mysql.sql
@@ -1,0 +1,288 @@
+-- CreateTable
+CREATE TABLE `usuarios` (
+    `id` VARCHAR(191) NOT NULL,
+    `nombre` VARCHAR(191) NOT NULL,
+    `email` VARCHAR(191) NOT NULL,
+    `celular` VARCHAR(191) NULL,
+    `password` VARCHAR(191) NOT NULL,
+    `rol` VARCHAR(191) NOT NULL DEFAULT 'VENDEDOR',
+    `activo` BOOLEAN NOT NULL DEFAULT true,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `usuarios_email_key`(`email`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `rifas` (
+    `id` VARCHAR(191) NOT NULL,
+    `nombre` VARCHAR(191) NOT NULL,
+    `descripcion` VARCHAR(191) NOT NULL,
+    `portadaUrl` VARCHAR(191) NULL,
+    `fechaSorteo` DATETIME(3) NOT NULL,
+    `precioPorBoleto` DOUBLE NOT NULL,
+    `precioUSD` DOUBLE NULL,
+    `totalBoletos` INTEGER NOT NULL,
+    `limitePorPersona` INTEGER NULL DEFAULT 10,
+    `estado` VARCHAR(191) NOT NULL DEFAULT 'BORRADOR',
+    `tiempoReserva` INTEGER NOT NULL DEFAULT 30,
+    `mostrarTopCompradores` BOOLEAN NOT NULL DEFAULT false,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `premios` (
+    `id` VARCHAR(191) NOT NULL,
+    `rifaId` VARCHAR(191) NOT NULL,
+    `titulo` VARCHAR(191) NOT NULL,
+    `descripcion` VARCHAR(191) NULL,
+    `cantidad` INTEGER NOT NULL DEFAULT 1,
+    `orden` INTEGER NULL,
+    `ticketGanadorId` VARCHAR(191) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `premios_ticketGanadorId_key`(`ticketGanadorId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `participantes` (
+    `id` VARCHAR(191) NOT NULL,
+    `nombre` VARCHAR(191) NOT NULL,
+    `celular` VARCHAR(191) NOT NULL,
+    `cedula` VARCHAR(191) NULL,
+    `email` VARCHAR(191) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `participantes_celular_key`(`celular`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `tickets` (
+    `id` VARCHAR(191) NOT NULL,
+    `numero` INTEGER NOT NULL,
+    `rifaId` VARCHAR(191) NOT NULL,
+    `participanteId` VARCHAR(191) NULL,
+    `compraId` VARCHAR(191) NULL,
+    `estado` VARCHAR(191) NOT NULL DEFAULT 'DISPONIBLE',
+    `monto` DOUBLE NULL,
+    `fechaReserva` DATETIME(3) NULL,
+    `fechaVencimiento` DATETIME(3) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `tickets_numero_rifaId_key`(`numero`, `rifaId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `compras` (
+    `id` VARCHAR(191) NOT NULL,
+    `rifaId` VARCHAR(191) NOT NULL,
+    `participanteId` VARCHAR(191) NOT NULL,
+    `cantidadTickets` INTEGER NOT NULL DEFAULT 1,
+    `monto` DOUBLE NOT NULL,
+    `montoTotal` DOUBLE NOT NULL,
+    `metodoPago` VARCHAR(191) NOT NULL DEFAULT 'TRANSFERENCIA',
+    `estadoPago` VARCHAR(191) NOT NULL DEFAULT 'PENDIENTE',
+    `voucherUrl` VARCHAR(191) NULL,
+    `imagenComprobante` VARCHAR(191) NULL,
+    `bancoId` VARCHAR(191) NULL,
+    `referencia` VARCHAR(191) NULL,
+    `paymentId` VARCHAR(191) NULL,
+    `fechaVencimiento` DATETIME(3) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `cuentas_bancarias` (
+    `id` VARCHAR(191) NOT NULL,
+    `banco` VARCHAR(191) NOT NULL,
+    `titular` VARCHAR(191) NOT NULL,
+    `numero` VARCHAR(191) NOT NULL,
+    `tipoCuenta` VARCHAR(191) NULL,
+    `activa` BOOLEAN NOT NULL DEFAULT true,
+    `orden` INTEGER NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `cuentas_bancarias_numero_key`(`numero`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `sorteos` (
+    `id` VARCHAR(191) NOT NULL,
+    `rifaId` VARCHAR(191) NOT NULL,
+    `numeroGanador` INTEGER NULL,
+    `ticketGanadorId` VARCHAR(191) NULL,
+    `metodo` VARCHAR(191) NOT NULL DEFAULT 'AUTOMATICO',
+    `semilla` VARCHAR(191) NULL,
+    `fechaSorteo` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `fechaHora` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `verificado` BOOLEAN NOT NULL DEFAULT false,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `sorteos_rifaId_key`(`rifaId`),
+    UNIQUE INDEX `sorteos_ticketGanadorId_key`(`ticketGanadorId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `notificaciones` (
+    `id` VARCHAR(191) NOT NULL,
+    `tipo` VARCHAR(191) NOT NULL,
+    `titulo` VARCHAR(191) NOT NULL,
+    `mensaje` VARCHAR(191) NOT NULL,
+    `leida` BOOLEAN NOT NULL DEFAULT false,
+    `usuarioId` VARCHAR(191) NULL,
+    `participanteId` VARCHAR(191) NULL,
+    `paraAdministradores` BOOLEAN NOT NULL DEFAULT false,
+    `metadata` VARCHAR(191) NULL,
+    `fechaLectura` DATETIME(3) NULL,
+    `creadaPor` VARCHAR(191) NULL,
+    `leidaPor` VARCHAR(191) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `audit_logs` (
+    `id` VARCHAR(191) NOT NULL,
+    `evento` VARCHAR(191) NOT NULL,
+    `accion` VARCHAR(191) NULL,
+    `usuarioId` VARCHAR(191) NULL,
+    `entidad` VARCHAR(191) NULL,
+    `entidadId` VARCHAR(191) NULL,
+    `detalles` VARCHAR(191) NULL,
+    `payload` VARCHAR(191) NULL,
+    `ipAddress` VARCHAR(191) NULL,
+    `userAgent` VARCHAR(191) NULL,
+    `timestamp` DATETIME(3) NULL,
+    `creadaPor` VARCHAR(191) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `configuraciones` (
+    `id` VARCHAR(191) NOT NULL,
+    `clave` VARCHAR(191) NOT NULL,
+    `valor` VARCHAR(191) NOT NULL,
+    `descripcion` VARCHAR(191) NULL,
+    `tipo` VARCHAR(191) NOT NULL DEFAULT 'STRING',
+    `categoria` VARCHAR(191) NOT NULL DEFAULT 'GENERAL',
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `configuraciones_clave_key`(`clave`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `refresh_tokens` (
+    `id` VARCHAR(191) NOT NULL,
+    `tokenHash` VARCHAR(191) NOT NULL,
+    `userId` VARCHAR(191) NOT NULL,
+    `revoked` BOOLEAN NOT NULL DEFAULT false,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `refresh_tokens_tokenHash_key`(`tokenHash`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `configuracion_sitio` (
+    `id` VARCHAR(191) NOT NULL,
+    `clave` VARCHAR(191) NOT NULL,
+    `valor` VARCHAR(191) NOT NULL,
+    `tipo` VARCHAR(191) NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `configuracion_sitio_clave_key`(`clave`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `metodos_pago` (
+    `id` VARCHAR(191) NOT NULL,
+    `nombre` VARCHAR(191) NOT NULL,
+    `tipo` VARCHAR(191) NOT NULL,
+    `descripcion` VARCHAR(191) NULL,
+    `imagen` VARCHAR(191) NULL,
+    `activo` BOOLEAN NOT NULL DEFAULT true,
+    `orden` INTEGER NOT NULL DEFAULT 0,
+    `numeroCuenta` VARCHAR(191) NULL,
+    `tipoCuenta` VARCHAR(191) NULL,
+    `cedula` VARCHAR(191) NULL,
+    `telefono` VARCHAR(191) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `metodos_pago_nombre_key`(`nombre`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `redes_sociales` (
+    `id` VARCHAR(191) NOT NULL,
+    `nombre` VARCHAR(191) NOT NULL,
+    `url` VARCHAR(191) NOT NULL,
+    `icono` VARCHAR(191) NULL,
+    `activo` BOOLEAN NOT NULL DEFAULT true,
+    `orden` INTEGER NOT NULL DEFAULT 0,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `redes_sociales_nombre_key`(`nombre`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `premios` ADD CONSTRAINT `premios_rifaId_fkey` FOREIGN KEY (`rifaId`) REFERENCES `rifas`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `premios` ADD CONSTRAINT `premios_ticketGanadorId_fkey` FOREIGN KEY (`ticketGanadorId`) REFERENCES `tickets`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `tickets` ADD CONSTRAINT `tickets_rifaId_fkey` FOREIGN KEY (`rifaId`) REFERENCES `rifas`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `tickets` ADD CONSTRAINT `tickets_participanteId_fkey` FOREIGN KEY (`participanteId`) REFERENCES `participantes`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `tickets` ADD CONSTRAINT `tickets_compraId_fkey` FOREIGN KEY (`compraId`) REFERENCES `compras`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `compras` ADD CONSTRAINT `compras_rifaId_fkey` FOREIGN KEY (`rifaId`) REFERENCES `rifas`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `compras` ADD CONSTRAINT `compras_participanteId_fkey` FOREIGN KEY (`participanteId`) REFERENCES `participantes`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `compras` ADD CONSTRAINT `compras_bancoId_fkey` FOREIGN KEY (`bancoId`) REFERENCES `cuentas_bancarias`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `sorteos` ADD CONSTRAINT `sorteos_rifaId_fkey` FOREIGN KEY (`rifaId`) REFERENCES `rifas`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `sorteos` ADD CONSTRAINT `sorteos_ticketGanadorId_fkey` FOREIGN KEY (`ticketGanadorId`) REFERENCES `tickets`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `refresh_tokens` ADD CONSTRAINT `refresh_tokens_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `usuarios`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.postgres.sql
+++ b/prisma/schema.postgres.sql
@@ -1,0 +1,312 @@
+-- CreateTable
+CREATE TABLE "usuarios" (
+    "id" TEXT NOT NULL,
+    "nombre" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "celular" TEXT,
+    "password" TEXT NOT NULL,
+    "rol" TEXT NOT NULL DEFAULT 'VENDEDOR',
+    "activo" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "usuarios_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "rifas" (
+    "id" TEXT NOT NULL,
+    "nombre" TEXT NOT NULL,
+    "descripcion" TEXT NOT NULL,
+    "portadaUrl" TEXT,
+    "fechaSorteo" TIMESTAMP(3) NOT NULL,
+    "precioPorBoleto" DOUBLE PRECISION NOT NULL,
+    "precioUSD" DOUBLE PRECISION,
+    "totalBoletos" INTEGER NOT NULL,
+    "limitePorPersona" INTEGER DEFAULT 10,
+    "estado" TEXT NOT NULL DEFAULT 'BORRADOR',
+    "tiempoReserva" INTEGER NOT NULL DEFAULT 30,
+    "mostrarTopCompradores" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "rifas_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "premios" (
+    "id" TEXT NOT NULL,
+    "rifaId" TEXT NOT NULL,
+    "titulo" TEXT NOT NULL,
+    "descripcion" TEXT,
+    "cantidad" INTEGER NOT NULL DEFAULT 1,
+    "orden" INTEGER,
+    "ticketGanadorId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "premios_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "participantes" (
+    "id" TEXT NOT NULL,
+    "nombre" TEXT NOT NULL,
+    "celular" TEXT NOT NULL,
+    "cedula" TEXT,
+    "email" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "participantes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tickets" (
+    "id" TEXT NOT NULL,
+    "numero" INTEGER NOT NULL,
+    "rifaId" TEXT NOT NULL,
+    "participanteId" TEXT,
+    "compraId" TEXT,
+    "estado" TEXT NOT NULL DEFAULT 'DISPONIBLE',
+    "monto" DOUBLE PRECISION,
+    "fechaReserva" TIMESTAMP(3),
+    "fechaVencimiento" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tickets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "compras" (
+    "id" TEXT NOT NULL,
+    "rifaId" TEXT NOT NULL,
+    "participanteId" TEXT NOT NULL,
+    "cantidadTickets" INTEGER NOT NULL DEFAULT 1,
+    "monto" DOUBLE PRECISION NOT NULL,
+    "montoTotal" DOUBLE PRECISION NOT NULL,
+    "metodoPago" TEXT NOT NULL DEFAULT 'TRANSFERENCIA',
+    "estadoPago" TEXT NOT NULL DEFAULT 'PENDIENTE',
+    "voucherUrl" TEXT,
+    "imagenComprobante" TEXT,
+    "bancoId" TEXT,
+    "referencia" TEXT,
+    "paymentId" TEXT,
+    "fechaVencimiento" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "compras_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "cuentas_bancarias" (
+    "id" TEXT NOT NULL,
+    "banco" TEXT NOT NULL,
+    "titular" TEXT NOT NULL,
+    "numero" TEXT NOT NULL,
+    "tipoCuenta" TEXT,
+    "activa" BOOLEAN NOT NULL DEFAULT true,
+    "orden" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "cuentas_bancarias_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "sorteos" (
+    "id" TEXT NOT NULL,
+    "rifaId" TEXT NOT NULL,
+    "numeroGanador" INTEGER,
+    "ticketGanadorId" TEXT,
+    "metodo" TEXT NOT NULL DEFAULT 'AUTOMATICO',
+    "semilla" TEXT,
+    "fechaSorteo" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "fechaHora" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "verificado" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "sorteos_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "notificaciones" (
+    "id" TEXT NOT NULL,
+    "tipo" TEXT NOT NULL,
+    "titulo" TEXT NOT NULL,
+    "mensaje" TEXT NOT NULL,
+    "leida" BOOLEAN NOT NULL DEFAULT false,
+    "usuarioId" TEXT,
+    "participanteId" TEXT,
+    "paraAdministradores" BOOLEAN NOT NULL DEFAULT false,
+    "metadata" TEXT,
+    "fechaLectura" TIMESTAMP(3),
+    "creadaPor" TEXT,
+    "leidaPor" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "notificaciones_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "audit_logs" (
+    "id" TEXT NOT NULL,
+    "evento" TEXT NOT NULL,
+    "accion" TEXT,
+    "usuarioId" TEXT,
+    "entidad" TEXT,
+    "entidadId" TEXT,
+    "detalles" TEXT,
+    "payload" TEXT,
+    "ipAddress" TEXT,
+    "userAgent" TEXT,
+    "timestamp" TIMESTAMP(3),
+    "creadaPor" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "configuraciones" (
+    "id" TEXT NOT NULL,
+    "clave" TEXT NOT NULL,
+    "valor" TEXT NOT NULL,
+    "descripcion" TEXT,
+    "tipo" TEXT NOT NULL DEFAULT 'STRING',
+    "categoria" TEXT NOT NULL DEFAULT 'GENERAL',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "configuraciones_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "refresh_tokens" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "revoked" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "refresh_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "configuracion_sitio" (
+    "id" TEXT NOT NULL,
+    "clave" TEXT NOT NULL,
+    "valor" TEXT NOT NULL,
+    "tipo" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "configuracion_sitio_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "metodos_pago" (
+    "id" TEXT NOT NULL,
+    "nombre" TEXT NOT NULL,
+    "tipo" TEXT NOT NULL,
+    "descripcion" TEXT,
+    "imagen" TEXT,
+    "activo" BOOLEAN NOT NULL DEFAULT true,
+    "orden" INTEGER NOT NULL DEFAULT 0,
+    "numeroCuenta" TEXT,
+    "tipoCuenta" TEXT,
+    "cedula" TEXT,
+    "telefono" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "metodos_pago_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "redes_sociales" (
+    "id" TEXT NOT NULL,
+    "nombre" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "icono" TEXT,
+    "activo" BOOLEAN NOT NULL DEFAULT true,
+    "orden" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "redes_sociales_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "usuarios_email_key" ON "usuarios"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "premios_ticketGanadorId_key" ON "premios"("ticketGanadorId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "participantes_celular_key" ON "participantes"("celular");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tickets_numero_rifaId_key" ON "tickets"("numero", "rifaId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "cuentas_bancarias_numero_key" ON "cuentas_bancarias"("numero");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sorteos_rifaId_key" ON "sorteos"("rifaId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sorteos_ticketGanadorId_key" ON "sorteos"("ticketGanadorId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "configuraciones_clave_key" ON "configuraciones"("clave");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "refresh_tokens_tokenHash_key" ON "refresh_tokens"("tokenHash");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "configuracion_sitio_clave_key" ON "configuracion_sitio"("clave");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "metodos_pago_nombre_key" ON "metodos_pago"("nombre");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "redes_sociales_nombre_key" ON "redes_sociales"("nombre");
+
+-- AddForeignKey
+ALTER TABLE "premios" ADD CONSTRAINT "premios_rifaId_fkey" FOREIGN KEY ("rifaId") REFERENCES "rifas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "premios" ADD CONSTRAINT "premios_ticketGanadorId_fkey" FOREIGN KEY ("ticketGanadorId") REFERENCES "tickets"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tickets" ADD CONSTRAINT "tickets_rifaId_fkey" FOREIGN KEY ("rifaId") REFERENCES "rifas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tickets" ADD CONSTRAINT "tickets_participanteId_fkey" FOREIGN KEY ("participanteId") REFERENCES "participantes"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tickets" ADD CONSTRAINT "tickets_compraId_fkey" FOREIGN KEY ("compraId") REFERENCES "compras"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "compras" ADD CONSTRAINT "compras_rifaId_fkey" FOREIGN KEY ("rifaId") REFERENCES "rifas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "compras" ADD CONSTRAINT "compras_participanteId_fkey" FOREIGN KEY ("participanteId") REFERENCES "participantes"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "compras" ADD CONSTRAINT "compras_bancoId_fkey" FOREIGN KEY ("bancoId") REFERENCES "cuentas_bancarias"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sorteos" ADD CONSTRAINT "sorteos_rifaId_fkey" FOREIGN KEY ("rifaId") REFERENCES "rifas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sorteos" ADD CONSTRAINT "sorteos_ticketGanadorId_fkey" FOREIGN KEY ("ticketGanadorId") REFERENCES "tickets"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "refresh_tokens" ADD CONSTRAINT "refresh_tokens_userId_fkey" FOREIGN KEY ("userId") REFERENCES "usuarios"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+


### PR DESCRIPTION
## Summary
- generate SQL schemas for MySQL/MariaDB and PostgreSQL from Prisma models
- add PDO-based PHP wrapper mirroring Prisma client export
- document SQL dumps and PHP usage for cPanel deployments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bd0e0202f08331973038b4eb749e15